### PR TITLE
Rework for cpp-sensor 0.7.0 and nginx 1.17.6

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,17 +1,33 @@
-FROM opentracing/nginx-opentracing
+FROM ubuntu:18.04
 
 RUN set -x \
   && apt-get update \
   && apt-get install --no-install-recommends --no-install-suggests -y \
               curl apt-transport-https iproute2 \
-  && apt-get install --no-install-recommends --no-install-suggests -y lynx curl
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+              lynx curl ca-certificates gnupg2
 
 ARG agent_key
 
 ENV INSTANA_AGENT_KEY=${agent_key}
 
-# Download extension from Artifactory
-RUN sensor_version=$(lynx -auth _:${INSTANA_AGENT_KEY} -dump -listonly https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/ | grep -o 'https:.*/[0-9]\+\.[0-9]\+\.[0-9]\+/' | rev | cut -d '/' -f 2 | rev | sort -V | tail -n1); \
-    curl --user _:${INSTANA_AGENT_KEY} --silent --output /usr/local/lib/libinstana_sensor.so https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/${sensor_version}/linux-amd64-libinstana_sensor.so
+# Add official Nginx repository
+RUN echo "deb http://nginx.org/packages/mainline/ubuntu/ bionic nginx" \
+     >> /etc/apt/sources.list \
+  && curl -fsSL https://nginx.org/keys/nginx_signing.key | apt-key add - \
+  && apt-get update
 
-RUN chmod 777 /usr/local/lib/libinstana_sensor.so
+# Install Nginx from official Nginx repository
+RUN nginx_version=`apt-cache madison nginx | cut -d '|' -f2 \
+     | tr -d "[:blank:]" | grep 1\.17\.6` \
+  && apt-get install nginx=${nginx_version} \
+  && rm -f /etc/nginx/nginx.conf \
+  && rm -Rf /etc/nginx/conf.d
+
+# Download extension from Artifactory
+RUN arti_path=https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/; \
+    sensor_version=$(lynx -auth _:${INSTANA_AGENT_KEY} -dump -listonly ${arti_path} | grep -o 'https:.*/[0-9]\+\.[0-9]\+\.[0-9]\+/' | rev | cut -d '/' -f 2 | rev | sort -V | tail -n1); \
+    curl --user _:${INSTANA_AGENT_KEY} --silent --output /usr/local/lib/libinstana_sensor.so ${arti_path}${sensor_version}/linux-amd64-libinstana_sensor.so && \
+    curl --user _:${INSTANA_AGENT_KEY} --silent --output /usr/lib/nginx/modules/ngx_http_opentracing_module.so ${arti_path}${sensor_version}/linux-amd64-nginx-1.17.6-ngx_http_ot_module.so
+
+CMD ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/nginx/instana-config.json
+++ b/nginx/instana-config.json
@@ -1,5 +1,5 @@
 {
-  "service": "nginx",
+  "service": "nginxtracing_nginx",
   "agent_host": "instana-agent",
   "agent_port": 42699
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,6 +2,8 @@ load_module modules/ngx_http_opentracing_module.so;
 
 events {}
 
+error_log /dev/stdout info;
+
 http {
   opentracing on;
   error_log /dev/stdout info;
@@ -12,13 +14,13 @@ http {
   }
 
   server {
-    error_log /var/log/nginx/debug.log debug;
+    error_log /dev/stdout info;
     listen 8080;
     server_name localhost;
 
     location /nginx_status {
- 	    stub_status;
- 	    allow all;    # don't ever push in production something like this :-)	
+       stub_status;
+       allow all;    # don't ever push in production something like this :-)
     }
 
     location ^~ / {


### PR DESCRIPTION
The files from the nginx-opentracing project cannot be used any
more as they could become incompatible. So use a plain Ubuntu 18.04
Bionic image instead. Set up the official Nginx mainline repository
and install Nginx 1.17.6. Adapt the nginx image Dockerfile and the
Nginx config to run with output to stdout. Download the Instana
ngx_http_opentracing_module for Nginx 1.17.6 as well. Adapt the
service name to "nginxtracing_nginx" to unify it with the Docker
image name.