### PR TITLE
instana-config.json: Show max_buffered_spans option

### DIFF
--- a/nginx/instana-config.json
+++ b/nginx/instana-config.json
@@ -1,5 +1,6 @@
 {
   "service": "nginxtracing_nginx",
   "agent_host": "instana-agent",
-  "agent_port": 42699
+  "agent_port": 42699,
+  "max_buffered_spans": 1000
 }


### PR DESCRIPTION
We introduced the new option with version 0.8.0. So show how it is
used by setting it to its default. Basically only less or equal to
0 is forbidden.