### PR TITLE
Binaries: Move support matrix to BINARIES.md

### DIFF
--- a/BINARIES.md
+++ b/BINARIES.md
@@ -1,0 +1,586 @@
+# NGINX tracing modules
+
+A list of NGINX versions follows which will guide you to the proper binaries
+required.
+
+## Select your NGINX version
+
+   * [Plus R22](#plus-r22)
+   * [Plus R21](#plus-r21)
+   * [Plus R20](#plus-r20)
+   * [Plus R19](#plus-r19)
+   * [Plus R18](#plus-r18)
+   * [1.19.0](#1190)
+   * [1.18.0](#1180)
+   * [1.17.10](#11710)
+   * [1.17.9](#1179)
+   * [1.17.8](#1178)
+   * [1.17.7](#1177)
+   * [1.17.6](#1176)
+   * [1.17.5](#1175)
+   * [1.17.4](#1174)
+   * [1.17.3](#1173)
+   * [1.17.2](#1172)
+   * [1.17.1](#1171)
+   * [1.17.0](#1170)
+   * [1.16.1](#1161)
+   * [1.16.0](#1160)
+   * [1.15.12](#11512)
+   * [1.15.10](#11510)
+   * [1.15.8 OpenResty](#1158-openresty)
+   * [1.15.0](#1150)
+   * [1.14.2](#1142)
+   * [1.14.1](#1141)
+   * [1.14.0](#1140)
+   * [1.13.6 OpenResty](#1136-openresty)
+
+## Plus R22
+
+See: [Version 1.19.0](#1190)
+
+## Plus R21
+
+See: [Version 1.17.9](#1179)
+
+## Plus R20
+
+See: [Version 1.17.6](#1176)
+
+## Plus R19
+
+See: [Version 1.17.3](#1173)
+
+## Plus R18
+
+See: [Version 1.15.10](#11510)
+
+## 1.19.0
+
+This version will be supported soon by release 1.0.0.
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.19.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-nginx-1.19.0-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.19.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-musl-nginx-1.19.0-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.19.0-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-nginx-1.19.0-ngx_http_ot_module_compatnfo.so)
+
+## 1.18.0
+
+This version will be supported soon by release 1.0.0.
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.18.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-nginx-1.18.0-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.18.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-musl-nginx-1.18.0-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.18.0-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-nginx-1.18.0-ngx_http_ot_module_compatnfo.so)
+
+### Distro Main Repo
+
+#### Alpine Linux 3.12
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.18.0-ngx_http_ot_module_alpine.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-musl-nginx-1.18.0-ngx_http_ot_module_alpine.so)
+
+## 1.17.10
+
+This version will be supported soon by release 1.0.0.
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.10-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.10-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.10-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-musl-nginx-1.17.10-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.10-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-nginx-1.17.10-ngx_http_ot_module_compatnfo.so)
+
+### Distro Main Repo
+
+#### Ubuntu 20.04
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.10-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/1.0.0/linux-amd64-nginx-1.17.10-ngx_http_ot_module.so)
+
+## 1.17.9
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.9-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.9-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.9-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.9-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.9-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.9-ngx_http_ot_module_compatnfo.so)
+
+## 1.17.8
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.8-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.8-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.8-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.8-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.8-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.8-ngx_http_ot_module_compatnfo.so)
+
+## 1.17.7
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.7-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.7-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.7-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.7-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.7-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.7-ngx_http_ot_module_compatnfo.so)
+
+## 1.17.6
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.6-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.6-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.6-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.6-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.6-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.6-ngx_http_ot_module_compatnfo.so)
+
+## 1.17.5
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.5-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.5-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.5-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.5-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.5-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.5-ngx_http_ot_module_compatnfo.so)
+
+## 1.17.4
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.4-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.4-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.4-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.4-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.4-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.4-ngx_http_ot_module_compatnfo.so)
+
+## 1.17.3
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.3-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.3-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.3-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.3-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.3-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.3-ngx_http_ot_module_compatnfo.so)
+
+## 1.17.2
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.2-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.2-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.2-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.2-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.2-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.2-ngx_http_ot_module_compatnfo.so)
+
+## 1.17.1
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.1-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.1-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.1-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.1-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.1-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.1-ngx_http_ot_module_compatnfo.so)
+
+## 1.17.0
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.0-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.17.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.17.0-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.17.0-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.17.0-ngx_http_ot_module_compatnfo.so)
+
+## 1.16.1
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.16.1-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.16.1-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.16.1-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.16.1-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.16.1-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.16.1-ngx_http_ot_module_compatnfo.so)
+
+### Distro Main Repo
+
+#### Alpine Linux 3.11/3.10
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.16.1-ngx_http_ot_module_alpine.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.16.1-ngx_http_ot_module_alpine.so)
+
+#### Amazon Linux 1/2018.03
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.16.1-ngx_http_ot_module_amazon.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.16.1-ngx_http_ot_module_amazon.so)
+
+## 1.16.0
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.16.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.16.0-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.16.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.16.0-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.16.0-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.16.0-ngx_http_ot_module_compatnfo.so)
+
+## 1.15.12
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.15.12-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.15.12-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.15.12-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.15.12-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.15.12-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.15.12-ngx_http_ot_module_compatnfo.so)
+
+## 1.15.10
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.15.10-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.15.10-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.15.10-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.15.10-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.15.10-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.15.10-ngx_http_ot_module_compatnfo.so)
+
+## 1.15.8 OpenResty
+
+OpenResty 1.15.8.1 and 1.15.8.2 use the same module. 1.15.8.3 is not supported yet.
+OpenResty is only supported on Amazon Linux 2018.03.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-openresty-1.15.8-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-openresty-1.15.8-ngx_http_ot_module.so)
+
+## 1.15.0
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.15.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.15.0-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.15.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.15.0-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.15.0-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.15.0-ngx_http_ot_module_compatnfo.so)
+
+## 1.14.2
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.14.2-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.14.2-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.14.2-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.14.2-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.14.2-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.14.2-ngx_http_ot_module_compatnfo.so)
+
+### Distro Main Repo
+
+#### Alpine Linux 3.9/3.8
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.14.2-ngx_http_ot_module_alpine.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.14.2-ngx_http_ot_module_alpine.so)
+
+## 1.14.1
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.14.1-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.14.1-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.14.1-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.14.1-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.14.1-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.14.1-ngx_http_ot_module_compatnfo.so)
+
+### Distro Main Repo
+
+#### CentOS/RHEL 8
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.14.1-ngx_http_ot_module_amazon.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.14.1-ngx_http_ot_module_amazon.so)
+
+## 1.14.0
+
+### NGINX Official Repo
+
+#### Latest glibc based Linux
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.14.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.14.0-ngx_http_ot_module.so)
+
+#### Alpine Linux
+
+[musl-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-libinstana_sensor.so)<br/>
+[musl-nginx-1.14.0-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-musl-nginx-1.14.0-ngx_http_ot_module.so)
+
+#### CentOS/RHEL 6
+
+This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN` and can be used
+for Amazon Linux 1/2018.03 as well.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.14.0-ngx_http_ot_module_compatnfo.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.14.0-ngx_http_ot_module_compatnfo.so)
+
+### Distro Main Repo
+
+#### Ubuntu 18.04
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-nginx-1.14.0-ngx_http_ot_module_ubuntu.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-nginx-1.14.0-ngx_http_ot_module_ubuntu.so)
+
+## 1.13.6 OpenResty
+
+OpenResty 1.13.6.1 and 1.13.6.2 use the same module.
+OpenResty is only supported on Amazon Linux 2018.03.
+
+[glibc-libinstana_sensor.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-libinstana_sensor.so)<br/>
+[glibc-openresty-1.13.6-ngx_http_ot_module.so](https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/0.8.0/linux-amd64-openresty-1.13.6-ngx_http_ot_module.so)

--- a/README.md
+++ b/README.md
@@ -97,21 +97,7 @@ The packages that we offer depend on:
 - The Libc variant used in your distribution (`glibc` or `musl`); you likely use `glibc`, unless you are using Alpine as base-image for your containers, in which case, it's `musl`.
 - (In some cases) the particular distribution (when the build used in some official packages is different enough to require bespoke adjustments on our side)
 
-Distro | Version | Nginx distro | Suffix | Nginx stable | Nginx Mainline | Openresty
---- | --- | --- | --- | --- | --- | ---
-Alpine Linux | 3.10 | 1.16.1 | _alpine | 1.14+, 1.16+ | 1.15+, 1.17+ | -
-Alpine Linux | 3.9 | 1.14.2 | _alpine | 1.14+, 1.16+ | 1.15+, 1.17+ | -
-Alpine Linux | 3.8 | 1.14.2 | _alpine | 1.14+, 1.16+ | 1.15+, 1.17+ | -
-Amazon Linux | 2018.03 | 1.14.1 | _amazon | CentOS 6*: 1.14+, 1.16+ | CentOS 6*: 1.15+, 1.17+; nginx+ 1.15.10 (r18-p1, no suffix) | 1.13.6, 1.15.8
-Amazon Linux | 2 | N/A | - |  CentOS 7: 1.14+, 1.16+ | CentOS 7: 1.15+, 1.17+ | -
-Amazon Linux | 1 | 1.14.1 | _amazon | CentOS 6*: 1.14+, 1.16+ | CentOS 6*: 1.15+, 1.17+ | -
-CentOS | 7 | N/A | - | 1.14+, 1.16+ | 1.15+, 1.17+ | -
-CentOS/RHEL6 | 6 | N/A | - | **: 1.14+, 1.16+ | **: 1.15+, 1.17+ | -
-Ubuntu | 18.04 | 1.14.0 | _ubuntu | 1.14+, 1.16+ | 1.15+, 1.17+ | -
-Ubuntu | 16.04 | N/A (too old 1.10.3) | - | 1.14+, 1.16+ | 1.15+, 1.17+ | -
-
-*: _compatnfo suffix (without the `HAVE_TCP_FASTOPEN` compile flag)
-**: _compatnfo suffix and glibc < 2.14
+Please find the required two binaries sorted by NGINX version in the separate file [BINARIES.md](BINARIES.md).
 
 We use the same module for both Nginx open-source and **Nginx Plus**.
 


### PR DESCRIPTION
It is easier to find the required binaries sorted by NGINX version.
So move the support matrix into BINARIES.md which provides the
proper download links for both binaries for all supported NGINX
versions and variants.