### PR TITLE
Release 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ Indeed, to avoid segfault, we use in our build of the NGINX OpenTracing module a
 
 ## Release History
 
+### 1.1.0 (2020-07-31)
+
+   * fixed the agent discovery if `/proc/$pid/sched` (`CONFIG_SCHED_DEBUG`) is not available
+
 ### 1.0.1 (2020-07-21)
 
    * added support for NGINX 1.19.1, OpenResty 1.17.8.1, 1.15.8.3

--- a/binaries.md
+++ b/binaries.md
@@ -14,51 +14,51 @@ For example, for some versions you may find two bundles for Alpine, one matching
 ### NGINX Plus R22
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.19.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.19.0.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.19.0_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.19.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.19.0.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.19.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.19.0_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.19.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX Plus R21
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.9.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.9.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.9_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.9.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.9.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.9_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.9_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.9_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX Plus R20
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.6.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.6_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.6.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.6.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.6_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.6_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.6_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX Plus R19
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.3.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.3_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.3.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.3_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.3_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.3_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX Plus R18
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.15.10.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.10_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.10.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.15.10.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.10_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.10_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.10_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ## NGINX
@@ -66,263 +66,263 @@ For example, for some versions you may find two bundles for Alpine, one matching
 ### NGINX 1.19.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.19.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.19.1.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.19.1_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.19.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.19.1.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.19.1_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.19.1_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.19.1_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.19.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.19.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.19.0.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.19.0_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.19.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.19.0.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.19.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.19.0_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.19.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.18.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.18.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.18.0.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.18.0_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.18.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.18.0.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.18.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.18.0_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.18.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.12](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.18.0_alpine.zip)
+  * [Alpine Linux 3.12](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.18.0_alpine.zip)
 
 ### NGINX 1.17.10
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.10.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.10_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.10.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.10.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.10_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.10_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.10_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.9
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.9.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.9.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.9_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.9.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.9.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.9_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.9_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.9_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.8
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.8.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.8.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.8_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.8.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.8.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.8_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.8_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.8_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.7
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.7.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.7.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.7_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.7.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.7.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.7_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.7_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.7_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.6
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.6.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.6_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.6.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.6.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.6_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.6_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.6_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.5.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.5_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.5.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.5.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.5_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.5_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.5_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.4.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.4_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.4.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.4.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.4_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.4_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.4_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.3.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.3_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.3.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.3_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.3_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.3_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.2.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.2_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.2.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.2_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.2_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.2_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.1.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.1_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.1.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.1_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.1_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.1_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.17.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.17.0.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.0_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.17.0.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.17.0_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.17.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.16.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.16.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.16.1.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.16.1_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.16.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.16.1.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.16.1_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.16.1_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.16.1_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 * [Amazon Linux Repository](https://aws.amazon.com/amazon-linux-ami/2018-03-packages/):
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.16.1_amazon.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.16.1_amazon.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.11/3.10](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.16.1_alpine.zip)
+  * [Alpine Linux 3.11/3.10](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.16.1_alpine.zip)
 
 ### NGINX 1.16.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.16.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.16.0.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.16.0_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.16.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.16.0.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.16.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.16.0_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.16.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.15.12
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.12.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.15.12.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.12_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.12.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.15.12.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.12_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.12_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.12_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.15.10
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.15.10.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.10_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.10.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.15.10.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.10_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.10_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.10_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.15.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.15.0.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.0_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.15.0.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.15.0_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.15.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 ### NGINX 1.14.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.14.2.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.2_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.14.2.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.2_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.2_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.2_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.9/3.8](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.14.2_alpine.zip)
+  * [Alpine Linux 3.9/3.8](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.14.2_alpine.zip)
 
 ### NGINX 1.14.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.14.1.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.1_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.14.1.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.1_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.1_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.1_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 * [Amazon Linux Repository](https://aws.amazon.com/amazon-linux-ami/2018-03-packages/):
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.1_amazon.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.1_amazon.zip)
 
 ### NGINX 1.14.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-musl-nginx-1.14.0.zip)
-  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.0_compatnfo.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-musl-nginx-1.14.0.zip)
+  * [CentOS/RHEL 6](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
-  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.0_compatnfo.zip)
+  * [Amazon Linux 1/2018.03](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.0_compatnfo.zip)
     * This NGINX variant is compiled without `NGX_HAVE_TCP_FASTOPEN`.
 
 * [Ubuntu Packages](https://packages.ubuntu.com/):
-  * [Ubuntu 18.04](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-nginx-1.14.0_ubuntu.zip)
+  * [Ubuntu 18.04](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-nginx-1.14.0_ubuntu.zip)
 
 ## OpenResty
 
 ### OpenResty 1.17.8
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.17.8.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-openresty-1.17.8_compat.zip)
+  * [OpenResty 1.17.8.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-openresty-1.17.8_compat.zip)
     * Supported only on Amazon Linux 1/2018.03
 
 ### OpenResty 1.15.8
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.15.8.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-openresty-1.15.8.zip)
+  * [OpenResty 1.15.8.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-openresty-1.15.8.zip)
     * Supported only on Amazon Linux 1/2018.03
-  * [OpenResty 1.15.8.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-openresty-1.15.8.zip)
+  * [OpenResty 1.15.8.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-openresty-1.15.8.zip)
     * Supported only on Amazon Linux 1/2018.03
-  * [OpenResty 1.15.8.3](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-openresty-1.15.8_compat.zip)
+  * [OpenResty 1.15.8.3](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-openresty-1.15.8_compat.zip)
     * Supported only on Amazon Linux 1/2018.03
 
 ### OpenResty 1.13.6
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.13.6.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-openresty-1.13.6.zip)
+  * [OpenResty 1.13.6.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-openresty-1.13.6.zip)
     * Supported only on Amazon Linux 1/2018.03
-  * [OpenResty 1.13.6.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.0.1/linux-amd64-glibc-openresty-1.13.6.zip)
+  * [OpenResty 1.13.6.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.1.0/linux-amd64-glibc-openresty-1.13.6.zip)
     * Supported only on Amazon Linux 1/2018.03


### PR DESCRIPTION
    binaries.md: Adapt to version 1.1.0
    
    Update all download links to version 1.1.0.
----
    README: Update the release history for 1.1.0

We've fixed the agent discovery if `/proc/$pid/sched` (`CONFIG_SCHED_DEBUG`) is not available. The connection to the Instana agent works in this case now but it takes more time until the agent finds the PID from the parent namespace as the Instana NGINX tracer cannot provide this information.