### PR TITLE
nginx: Update image and NGINX version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       args:
         download_key: ${download_key}
         agent_key: ${agent_key}
-        nginx_version: '1.17.2'
+        nginx_version: '1.21.1'
     networks:
       nginxmesh:
         aliases:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 AS tracing_dependencies
+FROM ubuntu:20.04 AS tracing_dependencies
 
 RUN set -x \
   && apt-get update \
@@ -29,7 +29,7 @@ RUN download_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOA
     mv ${LIBC_VERSION}-libinstana_sensor.so /opt/instana/nginx/libinstana_sensor.so && \
     mv ${LIBC_VERSION}-nginx-${NGINX_VERSION}-ngx_http_ot_module.so /opt/instana/nginx/ngx_http_opentracing_module.so;
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN set -x \
   && apt-get update \

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,7 +20,8 @@ http {
     server_name localhost;
 
     location /nginx_status {
-      stub_status;
+      stub_status on;
+      access_log off;
       allow all;    # don't ever push in production something like this :-)
     }
 


### PR DESCRIPTION
Use Ubuntu 20.04 as the base and use NGINX 1.21.1. Align the NGINX
config with the Instana docs esp. regarding `stub_status` config.