### PR TITLE
docker-compose: add possibility for a local Nginx module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .project
 org.eclipse*
 nginx/*.so
+agent/logs/*.log

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This will build and launch
 - `nginx` service, which routes all incoming requests to the ...
 - `server-app` service, a simple Spring Boot application that returns `200` to any HTTP request.
 
-After the agent is bootstrapped and starts accepting spans from NGINX, the resulting traces in the Analyze view will look like the following:
+After the agent is bootstrapped and starts accepting spans from NGINX, the resulting traces are logged into files named `spans-<timestamp_ns>` into the directory `agent/logs` and in the Analyze view will look like the following:
 
 ![Service dashboard](images/service-dashboard.png)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ This will build and launch
 - `nginx` service, which routes all incoming requests to the ...
 - `server-app` service, a simple Spring Boot application that returns `200` to any HTTP request.
 
-After the agent is bootstrapped and starts accepting spans from NGINX, the resulting traces are logged into files named `spans-<timestamp_ns>` into the directory `agent/logs` and in the Analyze view will look like the following:
+After the agent is bootstrapped and starts accepting spans from NGINX, the resulting traces are logged into files named `spans-<timestamp_ns>` in the directory `agent/logs`.
+
+In the Analyze view this looks like the following:
 
 ![Service dashboard](images/service-dashboard.png)
 

--- a/agent/com.instana.agent.main.sender.File.cfg
+++ b/agent/com.instana.agent.main.sender.File.cfg
@@ -1,0 +1,10 @@
+# Configuration of local logging. Changes will be hot-reloaded.
+# Activate logging of outgoing payloads to local disk by setting a non-empty
+# prefix. The log file will be written to data/log, and the file will have the
+# defined prefix followed by a timestamp.
+# Note: There is no automatic rotation of those files.
+prefix=spans
+
+# The file can be filtered to either "metrics" or "traces".
+# If empty or absent, there will be no filtering.
+type=traces

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/instana-config.json:/etc/instana-config.json
       # Include the following lines to override the nginx module, for local testing
-      #- ./nginx/ngx_http_opentracing_module.so:/opt/instana/nginx/ngx_http_opentracing_module.so
-      #- ./nginx/ngx_http_opentracing_module.so:/usr/lib/nginx/modules/ngx_http_opentracing_module.so
+      #- ./nginx/ngx_http_opentracing_module.so:/opt/instana/nginx/ngx_http_opentracing_module.so:ro
+      #- ./nginx/ngx_http_opentracing_module.so:/usr/lib/nginx/modules/ngx_http_opentracing_module.so:ro
     expose:
       - "8080"
 
@@ -50,11 +50,8 @@ services:
     volumes:
       - /var/run:/var/run
       - /run:/run
-      - /dev:/dev
-      - /sys:/sys
-      - /var/log:/var/log
       # Include the File.cfg so spans are written to disk. We use them to verify which spans have been sent to the agent.
-      - ./agent/com.instana.agent.main.sender.File.cfg:/opt/instana/agent/etc/instana/com.instana.agent.main.sender.File.cfg
+      - ./agent/com.instana.agent.main.sender.File.cfg:/opt/instana/agent/etc/instana/com.instana.agent.main.sender.File.cfg:ro
       # Mount the logs directly so we can directly access the span-*.log files to check the produced spans.
       - ./agent/logs:/opt/instana/agent/data/log
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/instana-config.json:/etc/instana-config.json
+      # Include the following lines to override the nginx module, for local testing
+      #- ./nginx/ngx_http_opentracing_module.so:/opt/instana/nginx/ngx_http_opentracing_module.so
+      #- ./nginx/ngx_http_opentracing_module.so:/usr/lib/nginx/modules/ngx_http_opentracing_module.so
     expose:
       - "8080"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,13 @@ services:
     volumes:
       - /var/run:/var/run
       - /run:/run
-      - /dev:/dev:ro
-      - /sys:/sys:ro
-      - /var/log:/var/log:ro
+      - /dev:/dev
+      - /sys:/sys
+      - /var/log:/var/log
+      # Include the File.cfg so spans are written to disk. We use them to verify which spans have been sent to the agent.
+      - ./agent/com.instana.agent.main.sender.File.cfg:/opt/instana/agent/etc/instana/com.instana.agent.main.sender.File.cfg
+      # Mount the logs directly so we can directly access the span-*.log files to check the produced spans.
+      - ./agent/logs:/opt/instana/agent/data/log
     networks:
       nginxmesh:
         aliases:
@@ -60,6 +64,11 @@ services:
       - INSTANA_DOWNLOAD_KEY=${download_key}
       - INSTANA_AGENT_KEY=${agent_key}
       - INSTANA_AGENT_ZONE=${agent_zone:-nginx-tracing-demo}
+    healthcheck:
+      test: ["CMD", "curl", "localhost:42699"]
+      interval: 8s
+      timeout: 10s
+      retries: 5
     expose:
       - "42699"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/instana-config.json:/etc/instana-config.json
-      # Include the following lines to override the nginx module, for local testing
+      # Instana developers only: Include the following lines to override the nginx module, for local testing
       #- ./nginx/ngx_http_opentracing_module.so:/opt/instana/nginx/ngx_http_opentracing_module.so:ro
       #- ./nginx/ngx_http_opentracing_module.so:/usr/lib/nginx/modules/ngx_http_opentracing_module.so:ro
     expose:


### PR DESCRIPTION
# WHAT
- Modify docker-compose file to use a local Nginx module
- Modify docker-compose file to enable the debug of agent's spans

# WHY
Improvements