### PR TITLE
Version 1.9.1 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ http {
       # It needs to be set for every block where `proxy_set_header`
       # is found. This can also be the case at `server` level.
       opentracing_propagate_context;
+      
+      # Using the `opentracing_remove_duplication` command enables the
+      # removal of the duplication of Server-Timing Header in the NGINX response.
+      # This duplication may occur if more than one tracer is involved in the
+      # the process chain of a request.
+      # The command can be inserted in the following contexts: http, server,
+      # location, backend.
+      opentracing_remove_duplication on;
 
       proxy_pass http://backend;
     }
@@ -223,6 +231,11 @@ Indeed, to avoid segfault, the Instana NGINX OpenTracing module is built includi
 The Instana [AutoTrace WebHook](https://www.ibm.com/docs/en/obi/current?topic=kubernetes-instana-autotrace-webhook) can automatically configure distributed tracing for Ingress NGINX and NGINX on Kubernetes and OpenShift.
 
 ## Release History
+
+### 1.9.1 (2024-08-22)
+
+  * Bug fix: Upper-case for `Server-Timing` header
+  * New Feature: Add command "`opentracing_remove_duplication`", to enable removal of duplicated `Server-Timing` headers in Nginx response.
 
 ### 1.9.0 (2024-03-07)
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ http {
       # is found. This can also be the case at `server` level.
       opentracing_propagate_context;
       
-      # Using the `opentracing_remove_duplication` command enables the
-      # removal of the duplication of Server-Timing Header in the NGINX response.
+      # The `opentracing_remove_duplication` directive enables the
+      # removal of the duplication of the Server-Timing header in the NGINX response.
       # This duplication may occur if more than one tracer is involved in the
       # the process chain of a request.
-      # The command can be inserted in the following contexts: http, server,
-      # location, backend.
+      # The directive can be inserted in the following contexts: http, server,
+      # location, and upstream.
       opentracing_remove_duplication on;
 
       proxy_pass http://backend;
@@ -235,7 +235,7 @@ The Instana [AutoTrace WebHook](https://www.ibm.com/docs/en/obi/current?topic=ku
 ### 1.9.1 (2024-08-22)
 
   * Bug fix: Upper-case for `Server-Timing` header
-  * New Feature: Add command "`opentracing_remove_duplication`", to enable removal of duplicated `Server-Timing` headers in Nginx response.
+  * New Feature: Add directive "`opentracing_remove_duplication`", to enable removal of duplicated `Server-Timing` headers in Nginx response.
 
 ### 1.9.0 (2024-03-07)
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The Instana [AutoTrace WebHook](https://www.ibm.com/docs/en/obi/current?topic=ku
 
 ### 1.9.0 (2024-03-07)
 
-  * New Feature: support of INSTANA_LOG_LEVEL
+  * New Feature: support of `INSTANA_LOG_LEVEL`
 
 ### 1.8.3 (2024-01-22)
 


### PR DESCRIPTION
[Jira Ticket](https://jsw.ibm.com/browse/INSTA-8308)

# What
Update changelog with 1.9.1 notes:
    * Bug fix: Upper-case for `Server-Timing` header

    * New Feature: Add command "`opentracing_remove_duplication`", to enable
      removal of duplicated `Server-Timing` headers in Nginx response.
Add to README the description of command "`opentracing_remove_duplication`" in the NGINX configuration section.

# Why
Compliance