### PR TITLE
README: Use better docker-compose commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ agent_zone=<name of the zone for the agent; default: nginx-tracing-demo>
 ## Build & Launch
 
 ```bash
-docker-compose build
-docker-compose up
+docker-compose down && docker-compose up --build
 ```
 
 This will build and launch


### PR DESCRIPTION
Often the network interfaces are not cleaned up properly. So always run `docker-compose down` first. The phases `build` and `up` can be combined. The build result is cached. This is fast. So use `docker-compose down && docker-compose up --build`.