### PR TITLE
Fix Ubuntu 20.04 EOL issue by using Ubuntu 24.04 instead

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       args:
         download_key: ${download_key}
         agent_key: ${agent_key}
-        nginx_version: '1.21.6'
+        nginx_version: '1.28.0'
     networks:
       nginxmesh:
         aliases:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -34,7 +34,7 @@ FROM ubuntu:22.04
 RUN set -x \
   && apt-get update \
   && apt-get install --no-install-recommends --no-install-suggests -y \
-              curl apt-transport-https ca-certificates iproute2 gnupg2
+              curl apt-transport-https ca-certificates iproute2 gnupg2 cron libpopt0 logrotate
 
 # Add official Nginx repositories
 RUN echo "deb http://nginx.org/packages/mainline/ubuntu/ jammy nginx" \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -36,8 +36,10 @@ RUN set -x \
   && apt-get install --no-install-recommends --no-install-suggests -y \
               curl apt-transport-https ca-certificates iproute2 gnupg2
 
-# Add official Nginx repository
+# Add official Nginx repositories
 RUN echo "deb http://nginx.org/packages/mainline/ubuntu/ jammy nginx" \
+     >> /etc/apt/sources.list \
+  && echo "deb http://nginx.org/packages/ubuntu/ jammy nginx" \
      >> /etc/apt/sources.list \
   && curl -fsSL https://nginx.org/keys/nginx_signing.key | apt-key add - \
   && apt-get update

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS tracing_dependencies
+FROM ubuntu:22.04 AS tracing_dependencies
 
 RUN set -x \
   && apt-get update \
@@ -29,7 +29,7 @@ RUN download_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOA
     mv ${LIBC_VERSION}-libinstana_sensor.so /opt/instana/nginx/libinstana_sensor.so && \
     mv ${LIBC_VERSION}-nginx-${NGINX_VERSION}-ngx_http_ot_module.so /opt/instana/nginx/ngx_http_opentracing_module.so;
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN set -x \
   && apt-get update \
@@ -37,7 +37,7 @@ RUN set -x \
               curl apt-transport-https ca-certificates iproute2 gnupg2
 
 # Add official Nginx repository
-RUN echo "deb http://nginx.org/packages/mainline/ubuntu/ focal nginx" \
+RUN echo "deb http://nginx.org/packages/mainline/ubuntu/ jammy nginx" \
      >> /etc/apt/sources.list \
   && curl -fsSL https://nginx.org/keys/nginx_signing.key | apt-key add - \
   && apt-get update

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS tracing_dependencies
+FROM ubuntu:24.04 AS tracing_dependencies
 
 RUN set -x \
   && apt-get update \
@@ -29,17 +29,17 @@ RUN download_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOA
     mv ${LIBC_VERSION}-libinstana_sensor.so /opt/instana/nginx/libinstana_sensor.so && \
     mv ${LIBC_VERSION}-nginx-${NGINX_VERSION}-ngx_http_ot_module.so /opt/instana/nginx/ngx_http_opentracing_module.so;
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN set -x \
   && apt-get update \
   && apt-get install --no-install-recommends --no-install-suggests -y \
-              curl apt-transport-https ca-certificates iproute2 gnupg2 cron libpopt0 logrotate
+              curl apt-transport-https ca-certificates iproute2 gnupg2 cron libpopt0 logrotate lsb-release
 
 # Add official Nginx repositories
-RUN echo "deb http://nginx.org/packages/mainline/ubuntu/ jammy nginx" \
+RUN echo "deb http://nginx.org/packages/mainline/ubuntu/ $(lsb_release -sc) nginx" \
      >> /etc/apt/sources.list \
-  && echo "deb http://nginx.org/packages/ubuntu/ jammy nginx" \
+  && echo "deb http://nginx.org/packages/ubuntu/ $(lsb_release -sc) nginx" \
      >> /etc/apt/sources.list \
   && curl -fsSL https://nginx.org/keys/nginx_signing.key | apt-key add - \
   && apt-get update


### PR DESCRIPTION
Commit list:
```
930b4a912ed6 nginx: Dockerfile: Bump to Ubuntu 22.04
a1e27fb88981 docker-compose: Bump NGINX version to 1.28.0
2c1c3660ff7a nginx: Dockerfile: Also add NGINX stable repo
91cbf8e173ce nginx: Dockerfile: Install cron, libpopt0, logrotate
98b019efb4d6 nginx: Dockerfile: Bump to Ubuntu 24.04
```

Pretty straight forward. Also using `lsb-release` package for auto-OS-codename handling now.