### PR TITLE
Enable NGINX tracing debug logging (`INSTANA_DEV=1`)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       # Instana developers only: Include the following lines to override the nginx module, for local testing
       #- ./nginx/ngx_http_opentracing_module.so:/opt/instana/nginx/ngx_http_opentracing_module.so:ro
       #- ./nginx/ngx_http_opentracing_module.so:/usr/lib/nginx/modules/ngx_http_opentracing_module.so:ro
+    environment:
+      - INSTANA_DEV=1
     expose:
       - "8080"
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,6 +4,14 @@ events {}
 
 error_log /dev/stdout info;
 
+# Whitelist environment variables used for tracer configuration to avoid
+# that NGINX wipes them. Takes precedence over instana-config.json.
+env INSTANA_SERVICE_NAME;
+env INSTANA_AGENT_HOST;
+env INSTANA_AGENT_PORT;
+env INSTANA_MAX_BUFFERED_SPANS;
+env INSTANA_DEV;
+
 http {
   error_log /dev/stdout info;
 


### PR DESCRIPTION
Just modify `docker-compose.yaml` to set environment variable `INSTANA_DEV=1` for the container `nginx` and whitelist tracer configuration environment variables in `nginx/nginx.conf` to make this change effective.
It is easier to turn it off and on as environment variable than as JSON key.