### PR TITLE
README, binaries: Add NGINX tracer 1.14.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ The Instana [AutoTrace WebHook](https://www.ibm.com/docs/en/obi/current?topic=ku
 
 ## Release History
 
+### 1.14.3 (2026-04-16)
+
+   * Add support for OpenResty 1.29.2.1 .. 1.29.2.3
+
 ### 1.14.2 (2026-03-25)
 
    * Bug fix: Add missing artifact for musl variant of NGINX version 1.27.2 in s390x architecture.

--- a/binaries.md
+++ b/binaries.md
@@ -17,14 +17,14 @@ To download the files, use `_` as the username and a valid agent key as password
 ### NGINX Plus R35
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.29.0.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.29.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.29.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.29.0.zip)
 
 ### NGINX Plus R34
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.27.4.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.27.4.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.27.4.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.27.4.zip)
 
 ### NGINX Plus R33
 
@@ -32,98 +32,98 @@ In the following list, *Glibc based Linux* stands for Linux versions that use Gl
 {: note}
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.27.2.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.27.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.27.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.27.2.zip)
 
 ### NGINX Plus R32
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.25.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.25.5.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.25.5.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.25.5.zip)
 
 ### NGINX Plus R31
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.25.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.25.3.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.25.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.25.3.zip)
 
 ### NGINX Plus R30
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.25.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.25.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.25.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.25.1.zip)
 
 ### NGINX Plus R29
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.23.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.23.4.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.23.4.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.23.4.zip)
 
 ### NGINX Plus R28
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.23.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.23.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.23.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.23.2.zip)
 
 ### NGINX Plus R27
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.6.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.6.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.6.zip)
 
 ### NGINX Plus R26
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.5.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.5.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.5.zip)
 
 ### NGINX Plus R25
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.3.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.3.zip)
 
 ### NGINX Plus R24
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.10.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.10.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.10.zip)
 
 ### NGINX Plus R23
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.5.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.5.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.5.zip)
 
 ### NGINX Plus R22
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.0.zip)
 
 ### NGINX Plus R21
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.9.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.9.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.9.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.9.zip)
 
 ### NGINX Plus R20
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.6.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.6.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.6.zip)
 
 ### NGINX Plus R19
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.3.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.3.zip)
 
 ### NGINX Plus R18
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.15.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.15.10.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.15.10.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.15.10.zip)
 
 ## NGINX
 
@@ -132,770 +132,770 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.29.6
 
 * [NGINX official repository](http://nginx.org/en/linux_packages.html):
-   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.29.6.zip)
-   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.29.6.zip)
-   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.29.6.zip)
-   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.29.6.zip)
-   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.29.6.zip)
-   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.29.6.zip)
-   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.29.6.zip)
-   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.29.6.zip)
+   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.29.6.zip)
+   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.29.6.zip)
+   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.29.6.zip)
+   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.29.6.zip)
+   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.29.6.zip)
+   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.29.6.zip)
+   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.29.6.zip)
+   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.29.6.zip)
 
 ### NGINX 1.29.5
 
 * [NGINX official repository](http://nginx.org/en/linux_packages.html):
-   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.29.5.zip)
-   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.29.5.zip)
-   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.29.5.zip)
-   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.29.5.zip)
-   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.29.5.zip)
-   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.29.5.zip)
-   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.29.5.zip)
-   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.29.5.zip)
+   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.29.5.zip)
+   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.29.5.zip)
+   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.29.5.zip)
+   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.29.5.zip)
+   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.29.5.zip)
+   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.29.5.zip)
+   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.29.5.zip)
+   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.29.5.zip)
 
 ### NGINX 1.29.4
 
 * [NGINX official repository](http://nginx.org/en/linux_packages.html):
-   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.29.4.zip)
-   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.29.4.zip)
-   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.29.4.zip)
-   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.29.4.zip)
-   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.29.4.zip)
-   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.29.4.zip)
-   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.29.4.zip)
-   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.29.4.zip)
+   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.29.4.zip)
+   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.29.4.zip)
+   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.29.4.zip)
+   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.29.4.zip)
+   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.29.4.zip)
+   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.29.4.zip)
+   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.29.4.zip)
+   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.29.4.zip)
 
 ### NGINX 1.29.3
 
 * [NGINX official repository](http://nginx.org/en/linux_packages.html):
-   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.29.3.zip)
-   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.29.3.zip)
-   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.29.3.zip)
-   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.29.3.zip)
-   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.29.3.zip)
-   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.29.3.zip)
-   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.29.3.zip)
-   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.29.3.zip)
+   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.29.3.zip)
+   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.29.3.zip)
+   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.29.3.zip)
+   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.29.3.zip)
+   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.29.3.zip)
+   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.29.3.zip)
+   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.29.3.zip)
+   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.29.3.zip)
 
 ### NGINX 1.29.2
 
 * [NGINX official repository](http://nginx.org/en/linux_packages.html):
-   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.29.2.zip)
-   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.29.2.zip)
-   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.29.2.zip)
-   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.29.2.zip)
-   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.29.2.zip)
-   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.29.2.zip)
-   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.29.2.zip)
-   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.29.2.zip)
+   * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.29.2.zip)
+   * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.29.2.zip)
+   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.29.2.zip)
+   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.29.2.zip)
+   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.29.2.zip)
+   * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.29.2.zip)
+   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.29.2.zip)
+   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.29.2.zip)
 
 ### NGINX 1.29.1
 
 * [NGINX official repository](http://nginx.org/en/linux_packages.html):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.29.1.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.29.1.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.29.1.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.29.1.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.29.1.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.29.1.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.29.1.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.29.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.29.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.29.1.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.29.1.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.29.1.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.29.1.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.29.1.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.29.1.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.29.1.zip)
 
 ### NGINX 1.29.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.29.0.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.29.0.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.29.0.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.29.0.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.29.0.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.29.0.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.29.0.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.29.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.29.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.29.0.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.29.0.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.29.0.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.29.0.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.29.0.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.29.0.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.29.0.zip)
 
 ## NGINX 1.28.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.28.2.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.28.2.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.28.2.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.28.2.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.28.2.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.28.2.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.28.2.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.28.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.28.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.28.2.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.28.2.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.28.2.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.28.2.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.28.2.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.28.2.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.28.2.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [amd64 Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.28.2_alpquic.zip)
-  * [aarch64 Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.28.2_alpquic.zip)
-  * [ppc64le Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.28.2_alpquic.zip)
-  * [s390x Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.28.2_alpquic.zip)
+  * [amd64 Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.28.2_alpquic.zip)
+  * [aarch64 Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.28.2_alpquic.zip)
+  * [ppc64le Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.28.2_alpquic.zip)
+  * [s390x Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.28.2_alpquic.zip)
 
 ### NGINX 1.28.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.28.1.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.28.1.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.28.1.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.28.1.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.28.1.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.28.1.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.28.1.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.28.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.28.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.28.1.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.28.1.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.28.1.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.28.1.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.28.1.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.28.1.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.28.1.zip)
 
 ### NGINX 1.28.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.28.0.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.28.0.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.28.0.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.28.0.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.28.0.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.28.0.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.28.0.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.28.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.28.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.28.0.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.28.0.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.28.0.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.28.0.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.28.0.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.28.0.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.28.0.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [amd64 Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.28.0_alpquic.zip)
+  * [amd64 Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.28.0_alpquic.zip)
 
 ### NGINX 1.27.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.27.5.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.27.5.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.27.5.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.27.5.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.27.5.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.27.5.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.27.5.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.27.5.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.27.5.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.27.5.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.27.5.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.27.5.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.27.5.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.27.5.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.27.5.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.27.5.zip)
 
 ### NGINX 1.27.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.27.4.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.27.4.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.27.4.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.27.4.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.27.4.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.27.4.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.27.4.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.27.4.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.27.4.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.27.4.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.27.4.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.27.4.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.27.4.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.27.4.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.27.4.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.27.4.zip)
 
 ### NGINX 1.27.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.27.3.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.27.3.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.27.3.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.27.3.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.27.3.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.27.3.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.27.3.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.27.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.27.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.27.3.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.27.3.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.27.3.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.27.3.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.27.3.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.27.3.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.27.3.zip)
 
 ### NGINX 1.27.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.27.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.27.2.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.27.2.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.27.2.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.27.2.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.27.2.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.27.2.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.27.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.27.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.27.2.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.27.2.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.27.2.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.27.2.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.27.2.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.27.2.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.27.2.zip)
 
 ### NGINX 1.27.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.27.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.27.1.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.27.1.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.27.1.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.27.1.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.27.1.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.27.1.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.27.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.27.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.27.1.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.27.1.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.27.1.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.27.1.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.27.1.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.27.1.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.27.1.zip)
 
 ### NGINX 1.27.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.27.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.27.0.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.27.0.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.27.0.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.27.0.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.27.0.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.27.0.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.27.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.27.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.27.0.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.27.0.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.27.0.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.27.0.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.27.0.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.27.0.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.27.0.zip)
 
 ### NGINX 1.26.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.26.3.zip)
-  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.26.3.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.26.3.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.26.3.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.26.3.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.26.3.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.26.3.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.26.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.26.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.26.3.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.26.3.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.26.3.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.26.3.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.26.3.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.26.3.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.26.3.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [amd64 Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.26.3_alpine.zip)
-  * [aarch64 Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.26.3_alpine.zip)
-  * [ppc64le Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.26.3_alpine.zip)
-  * [s390x Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.26.3_alpine.zip)
+  * [amd64 Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.26.3_alpine.zip)
+  * [aarch64 Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.26.3_alpine.zip)
+  * [ppc64le Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.26.3_alpine.zip)
+  * [s390x Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.26.3_alpine.zip)
 
 ### NGINX 1.26.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.26.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.26.2.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.26.2.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.26.2.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.26.2.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.26.2.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.26.2.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.26.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.26.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.26.2.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.26.2.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.26.2.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.26.2.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.26.2.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.26.2.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.26.2.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.26.2_alpine.zip)
+  * [Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.26.2_alpine.zip)
 
 ### NGINX 1.26.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.26.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.26.1.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.26.1.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.26.1.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.26.1.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.26.1.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.26.1.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.26.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.26.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.26.1.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.26.1.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.26.1.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.26.1.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.26.1.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.26.1.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.26.1.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.26.1_alpine.zip)
+  * [Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.26.1_alpine.zip)
 
 ### NGINX 1.26.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.26.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.26.0.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.26.0.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.26.0.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.26.0.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.26.0.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.26.0.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.26.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.26.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.26.0.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.26.0.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.26.0.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.26.0.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.26.0.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.26.0.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.26.0.zip)
 
 ### NGINX 1.25.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.25.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.25.5.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.25.5.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.25.5.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.25.5.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.25.5.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.25.5.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.25.5.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.25.5.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.25.5.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.25.5.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.25.5.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.25.5.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.25.5.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.25.5.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.25.5.zip)
 
 ### NGINX 1.25.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.25.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.25.4.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.25.4.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.25.4.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.25.4.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.25.4.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.25.4.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.25.4.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.25.4.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.25.4.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.25.4.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.25.4.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.25.4.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.25.4.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.25.4.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.25.4.zip)
 
 ### NGINX 1.25.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.25.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.25.3.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.25.3.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.25.3.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.25.3.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.25.3.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.25.3.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.25.3.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.25.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.25.3.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.25.3.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.25.3.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.25.3.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.25.3.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.25.3.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.25.3.zip)
 
 ### NGINX 1.25.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.25.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.25.2.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.25.2.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.25.2.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.25.2.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.25.2.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.25.2.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.25.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.25.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.25.2.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.25.2.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.25.2.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.25.2.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.25.2.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.25.2.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.25.2.zip)
 
 
 ### NGINX 1.25.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.25.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.25.1.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.25.1.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.25.1.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.25.1.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.25.1.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.25.1.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.25.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.25.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.25.1.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.25.1.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.25.1.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.25.1.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.25.1.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.25.1.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.25.1.zip)
 
 ### NGINX 1.25.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.25.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.25.0.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.25.0.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.25.0.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.25.0.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.25.0.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.25.0.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.25.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.25.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.25.0.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.25.0.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.25.0.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.25.0.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.25.0.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.25.0.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.25.0.zip)
 
 ### NGINX 1.24.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.24.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.24.0.zip)
-  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-glibc-nginx-1.24.0.zip)
-  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-aarch64-musl-nginx-1.24.0.zip)
-  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-glibc-nginx-1.24.0.zip)
-  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-ppc64le-musl-nginx-1.24.0.zip)
-  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-glibc-nginx-1.24.0.zip)
-  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-s390x-musl-nginx-1.24.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.24.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.24.0.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-glibc-nginx-1.24.0.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-aarch64-musl-nginx-1.24.0.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-glibc-nginx-1.24.0.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-ppc64le-musl-nginx-1.24.0.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-glibc-nginx-1.24.0.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-s390x-musl-nginx-1.24.0.zip)
 
 ### NGINX 1.23.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.23.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.23.4.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.23.4.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.23.4.zip)
 
 ### NGINX 1.23.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.23.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.23.3.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.23.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.23.3.zip)
 
 ### NGINX 1.23.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.23.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.23.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.23.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.23.2.zip)
 
 ### NGINX 1.23.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.23.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.23.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.23.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.23.1.zip)
 
 ### NGINX 1.23.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.23.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.23.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.23.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.23.0.zip)
 
 ### NGINX 1.22.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.22.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.22.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.22.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.22.1.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.16](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.22.1_alpine.zip)
+  * [Alpine Linux 3.16](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.22.1_alpine.zip)
 
 ### NGINX 1.22.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.22.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.22.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.22.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.22.0.zip)
 
 ### NGINX 1.21.6
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.6.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.6.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.6.zip)
 
 ### NGINX 1.21.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.5.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.5.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.5.zip)
 
 ### NGINX 1.21.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.4.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.4.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.4.zip)
 
 ### NGINX 1.21.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.3.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.3.zip)
 
 ### NGINX 1.21.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.2.zip)
 
 ### NGINX 1.21.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.1.zip)
 
 ### NGINX 1.21.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.21.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.21.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.21.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.21.0.zip)
 
 ### NGINX 1.20.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.20.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.20.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.20.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.20.2.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.14/3.15](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.20.2_alpine.zip)
+  * [Alpine Linux 3.14/3.15](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.20.2_alpine.zip)
 
 ### NGINX 1.20.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.20.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.20.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.20.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.20.1.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.20.1_alpine.zip)
+  * [Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.20.1_alpine.zip)
 
 ### NGINX 1.20.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.20.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.20.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.20.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.20.0.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.20.0_alpine.zip)
+  * [Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.20.0_alpine.zip)
 
 ### NGINX 1.19.10
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.10.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.10.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.10.zip)
 
 ### NGINX 1.19.9
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.9.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.9.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.9.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.9.zip)
 
 ### NGINX 1.19.8
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.8.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.8.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.8.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.8.zip)
 
 ### NGINX 1.19.7
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.7.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.7.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.7.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.7.zip)
 
 ### NGINX 1.19.6
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.6.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.6.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.6.zip)
 
 ### NGINX 1.19.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.5.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.5.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.5.zip)
 
 ### NGINX 1.19.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.4.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.4.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.4.zip)
 
 ### NGINX 1.19.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.3.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.3.zip)
 
 ### NGINX 1.19.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.2.zip)
 
 ### NGINX 1.19.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.1.zip)
 
 ### NGINX 1.19.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.19.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.19.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.19.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.19.0.zip)
 
 ### NGINX 1.18.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.18.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.18.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.18.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.18.0.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.12](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.18.0_alpine.zip)
+  * [Alpine Linux 3.12](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.18.0_alpine.zip)
 
 ### NGINX 1.17.10
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.10.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.10.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.10.zip)
 
 ### NGINX 1.17.9
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.9.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.9.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.9.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.9.zip)
 
 ### NGINX 1.17.8
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.8.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.8.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.8.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.8.zip)
 
 ### NGINX 1.17.7
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.7.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.7.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.7.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.7.zip)
 
 ### NGINX 1.17.6
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.6.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.6.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.6.zip)
 
 ### NGINX 1.17.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.5.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.5.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.5.zip)
 
 ### NGINX 1.17.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.4.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.4.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.4.zip)
 
 ### NGINX 1.17.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.3.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.3.zip)
 
 ### NGINX 1.17.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.2.zip)
 
 ### NGINX 1.17.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.1.zip)
 
 ### NGINX 1.17.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.17.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.17.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.17.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.17.0.zip)
 
 ### NGINX 1.16.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.16.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.16.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.16.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.16.1.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.11/3.10](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.16.1_alpine.zip)
+  * [Alpine Linux 3.11/3.10](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.16.1_alpine.zip)
 
 * [EPEL Repository](https://fedoraproject.org/wiki/EPEL):
-  * [CentOS/RHEL 7](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.16.1_amazon.zip)
+  * [CentOS/RHEL 7](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.16.1_amazon.zip)
 
 ### NGINX 1.16.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.16.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.16.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.16.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.16.0.zip)
 
 ### NGINX 1.15.12
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.15.12.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.15.12.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.15.12.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.15.12.zip)
 
 ### NGINX 1.15.10
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.15.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.15.10.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.15.10.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.15.10.zip)
 
 ### NGINX 1.15.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.15.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.15.3.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.15.3.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.15.3.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.15.3_alpine.zip)
+  * [Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.15.3_alpine.zip)
 
 * [Debian Packages](https://www.debian.org/distrib/packages#view)
-  * [Debian 10/9](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.15.3_ubuntu.zip)
+  * [Debian 10/9](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.15.3_ubuntu.zip)
 
 ### NGINX 1.15.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.15.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.15.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.15.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.15.0.zip)
 
 ### NGINX 1.14.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.14.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.14.2.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.14.2.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.14.2.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.9/3.8](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.14.2_alpine.zip)
+  * [Alpine Linux 3.9/3.8](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.14.2_alpine.zip)
 
 * [Debian Packages](https://www.debian.org/distrib/packages#view)
-  * [Debian 10/9](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.14.2_ubuntu.zip)
+  * [Debian 10/9](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.14.2_ubuntu.zip)
 
 ### NGINX 1.14.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.14.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.14.1.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.14.1.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.14.1.zip)
 
 ### NGINX 1.14.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.14.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-musl-nginx-1.14.0.zip)
+  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.14.0.zip)
+  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.14.0.zip)
 
 * [Ubuntu Packages](https://packages.ubuntu.com/):
-  * [Ubuntu 18.04](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-nginx-1.14.0_ubuntu.zip)
+  * [Ubuntu 18.04](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.14.0_ubuntu.zip)
 
 ## OpenResty
 
 ### OpenResty 1.27.1
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.27.1.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.27.1_compat.zip)
+  * [OpenResty 1.27.1.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.27.1_compat.zip)
     * Supported only on Amazon Linux and CentOS Stream 9 and later
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
-  * [OpenResty 1.27.1.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.27.1_compat.zip)
+  * [OpenResty 1.27.1.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.27.1_compat.zip)
 
 ### OpenResty 1.25.3
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.25.3.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.25.3_compat.zip)
+  * [OpenResty 1.25.3.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.25.3_compat.zip)
     * Supported only on Amazon Linux and CentOS Stream 9 and later
-  * [OpenResty 1.25.3.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.25.3_compat.zip)
+  * [OpenResty 1.25.3.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.25.3_compat.zip)
     * Supported only on Amazon Linux and CentOS Stream 9 and later
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
-  * [OpenResty 1.25.3.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.25.3.zip)
-  * [OpenResty 1.25.3.2 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.25.3_quic.zip)
+  * [OpenResty 1.25.3.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.25.3.zip)
+  * [OpenResty 1.25.3.2 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.25.3_quic.zip)
 
 ### OpenResty 1.21.4
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.21.4.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.21.4_compat.zip)
+  * [OpenResty 1.21.4.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.21.4_compat.zip)
     * Supported only on Amazon Linux and CentOS
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
-  * [OpenResty 1.21.4.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.21.4.zip)
-  * [OpenResty 1.21.4.1 CentOS](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.21.4_compat.zip)
+  * [OpenResty 1.21.4.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.21.4.zip)
+  * [OpenResty 1.21.4.1 CentOS](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.21.4_compat.zip)
 
 ### OpenResty 1.19.9
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.19.9.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.9_compat.zip)
+  * [OpenResty 1.19.9.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.9_compat.zip)
     * Supported only on Amazon Linux and CentOS
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
-  * [OpenResty 1.19.9.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.9.zip)
-  * [OpenResty 1.19.9.1 CentOS](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.9_compat.zip)
+  * [OpenResty 1.19.9.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.9.zip)
+  * [OpenResty 1.19.9.1 CentOS](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.9_compat.zip)
 
 ### OpenResty 1.19.3
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.19.3.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.3_compat.zip)
+  * [OpenResty 1.19.3.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.3_compat.zip)
     * Supported only on Amazon Linux and CentOS
-  * [OpenResty 1.19.3.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.3_compat.zip)
+  * [OpenResty 1.19.3.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.3_compat.zip)
     * Supported only on Amazon Linux and CentOS
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
-  * [OpenResty 1.19.3.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.3.zip)
-  * [OpenResty 1.19.3.2 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.3.zip)
-  * [OpenResty 1.19.3.1 CentOS](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.3_compat.zip)
-  * [OpenResty 1.19.3.2 CentOS](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.3_compat.zip)
+  * [OpenResty 1.19.3.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.3.zip)
+  * [OpenResty 1.19.3.2 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.3.zip)
+  * [OpenResty 1.19.3.1 CentOS](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.3_compat.zip)
+  * [OpenResty 1.19.3.2 CentOS](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.3_compat.zip)
 
 * [3scale containers](https://quay.io/repository/3scale/s2i-openresty-centos7?tag=latest&tab=tags)
-  * [OpenResty 1.19.3.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.19.3.zip)
+  * [OpenResty 1.19.3.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.19.3.zip)
 
 ### OpenResty 1.17.8
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.17.8.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.17.8_compat.zip)
+  * [OpenResty 1.17.8.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.17.8_compat.zip)
     * Supported only on Amazon Linux
-  * [OpenResty 1.17.8.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.17.8_compat.zip)
+  * [OpenResty 1.17.8.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.17.8_compat.zip)
     * Supported only on Amazon Linux
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
-  * [OpenResty 1.17.8.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.17.8.zip)
+  * [OpenResty 1.17.8.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.17.8.zip)
     * Supported only for Debian based images
 
 ### OpenResty 1.17.4
 
 * [3scale containers](https://quay.io/repository/3scale/s2i-openresty-centos7?tag=latest&tab=tags)
-  * [OpenResty 1.17.4.1rc0](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.17.4_3scale.zip)
+  * [OpenResty 1.17.4.1rc0](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.17.4_3scale.zip)
 
 ### OpenResty 1.15.8
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.15.8.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.15.8.zip)
+  * [OpenResty 1.15.8.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.15.8.zip)
     * Supported only on Amazon Linux
-  * [OpenResty 1.15.8.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.15.8.zip)
+  * [OpenResty 1.15.8.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.15.8.zip)
     * Supported only on Amazon Linux
-  * [OpenResty 1.15.8.3](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.15.8_compat.zip)
+  * [OpenResty 1.15.8.3](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.15.8_compat.zip)
     * Supported only on Amazon Linux
 
 ### OpenResty 1.13.6
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
-  * [OpenResty 1.13.6.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.13.6.zip)
+  * [OpenResty 1.13.6.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.13.6.zip)
     * Supported only on Amazon Linux
-  * [OpenResty 1.13.6.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.2/linux-amd64-glibc-openresty-1.13.6.zip)
+  * [OpenResty 1.13.6.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.13.6.zip)
     * Supported only on Amazon Linux

--- a/binaries.md
+++ b/binaries.md
@@ -807,6 +807,15 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 
 ## OpenResty
 
+### OpenResty 1.29.2
+
+* [OpenResty Repository](https://openresty.org/en/linux-packages.html):
+  * [OpenResty 1.29.2.1 .. 1.29.2.3](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.29.2_compat.zip)
+    * Supported only on Amazon Linux and CentOS Stream 9 and later
+
+* [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
+  * [OpenResty 1.29.2.2 .. 1.29.2.3 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-openresty-1.29.2_compat.zip)
+
 ### OpenResty 1.27.1
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):


### PR DESCRIPTION
Commits:
**binaries.md: Bump tracer version to 1.14.3**

Vim command: `%s/\/1\.14\.2\//\/1.14.3\//g`
diff: `git diff --word-diff-regex='[0-9]+\.[0-9]+\.[0-9]+'`

------------------

**binaries: Add OpenResty 1.29.2 binaries**
    
Those all apply to all OpenResty 1.29.2.1..1.29.2.3 variants.
For 1.29.2.1, there are no Debian based openresty/openresty
containers published.

-----------------

**README: Add 1.14.3 to release history**