### PR TITLE
README, binaries: Add NGINX Plus R36 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ The Instana [AutoTrace WebHook](https://www.ibm.com/docs/en/obi/current?topic=ku
 ### 1.14.3 (2026-04-16)
 
    * Add support for OpenResty 1.29.2.1 .. 1.29.2.3
+   * Add support for NGINX Plus R36
 
 ### 1.14.2 (2026-03-25)
 

--- a/binaries.md
+++ b/binaries.md
@@ -14,6 +14,12 @@ To download the files, use `_` as the username and a valid agent key as password
 
 ## NGINX Plus
 
+### NGINX Plus R36
+
+* [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-glibc-nginx-1.29.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.3/linux-amd64-musl-nginx-1.29.3.zip)
+
 ### NGINX Plus R35
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):


### PR DESCRIPTION
Just add the missing binary links and add this to the latest release history.
Those binaries are available since tracer version 1.12.0 actually.