### PR TITLE
client-app, server-app: Fix Docker images by prefixing 'amd64/'

### DIFF
--- a/client-app/Dockerfile
+++ b/client-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim AS nginx-tracing-client-app-build
+FROM amd64/openjdk:11-jdk-slim AS nginx-tracing-client-app-build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y --no-install-recommends --no-install-suggests \
@@ -9,7 +9,7 @@ WORKDIR /opt/client-app/
 COPY . .
 RUN ./mvnw clean package
 
-FROM openjdk:11-jre-slim
+FROM amd64/openjdk:11-jre-slim
 
 VOLUME /tmp
 WORKDIR /opt/client-app/

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim AS nginx-tracing-server-app-build
+FROM amd64/openjdk:11-jdk-slim AS nginx-tracing-server-app-build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y --no-install-recommends --no-install-suggests \
@@ -9,7 +9,7 @@ WORKDIR /opt/server-app/
 COPY . .
 RUN ./mvnw clean package
 
-FROM openjdk:11-jre-slim
+FROM amd64/openjdk:11-jre-slim
 
 VOLUME /tmp
 WORKDIR /opt/server-app/


### PR DESCRIPTION
The Docker images `openjdk:11-jdk-slim` are not available anymore. So prefix the image names with `amd64/` as a minimal fix.