### PR TITLE
Add additional ARM64 v8 (`aarch64`) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository contains a demo for Instana's [NGINX](https://www.nginx.com/) tr
 
 ## Prerequisites
 
-A `docker-compose` installation running on your machine. This demo has been created and tested on Mac OS X with `docker-compose` and `docker-machine`.
+A `docker-compose` installation running on your `x86_64` (`amd64`) or ARM64 v8 (`aarch64`) machine.
+This demo has been created and tested on Mac OS X with `docker-compose` and `docker-machine`.
 
 ## Configure
 

--- a/client-app/Dockerfile
+++ b/client-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/openjdk:11-jdk-slim AS nginx-tracing-client-app-build
+FROM azul/zulu-openjdk:11 AS nginx-tracing-client-app-build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y --no-install-recommends --no-install-suggests \
@@ -9,7 +9,7 @@ WORKDIR /opt/client-app/
 COPY . .
 RUN ./mvnw clean package
 
-FROM amd64/openjdk:11-jre-slim
+FROM azul/zulu-openjdk:11
 
 VOLUME /tmp
 WORKDIR /opt/client-app/

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -23,7 +23,8 @@ RUN download_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOA
     sensor_version=$(lynx -auth _:${download_key} -dump -listonly ${ARTI_PATH} | grep -o 'https:.*/[0-9]\+\.[0-9]\+\.[0-9]\+/' | rev | cut -d '/' -f 2 | rev | sort -V | tail -n1); \
     echo "Using sensor version ${sensor_version} for NGINX ${NGINX_VERSION}."; \
     tmp_file="tmp.zip"; tmp_dir="/tmp/nginx_tracing"; mkdir -p "${tmp_dir}" && cd "${tmp_dir}" && \
-    curl --user _:${download_key} --silent --output ${tmp_file} ${ARTI_PATH}${sensor_version}/linux-amd64-${LIBC_VERSION}-nginx-${NGINX_VERSION}.zip --fail && \
+    ngx_arch="$(uname -m)" && if [ "$ngx_arch" = "x86_64" ]; then ngx_arch="amd64"; fi; echo "CPU arch: ${ngx_arch}"; \
+    curl --user _:${download_key} --silent --output ${tmp_file} ${ARTI_PATH}${sensor_version}/linux-${ngx_arch}-${LIBC_VERSION}-nginx-${NGINX_VERSION}.zip --fail && \
     unzip ${tmp_file} && \
     mkdir -p /opt/instana/nginx && \
     mv ${LIBC_VERSION}-libinstana_sensor.so /opt/instana/nginx/libinstana_sensor.so && \

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/openjdk:11-jdk-slim AS nginx-tracing-server-app-build
+FROM azul/zulu-openjdk:11 AS nginx-tracing-server-app-build
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y --no-install-recommends --no-install-suggests \
@@ -9,7 +9,7 @@ WORKDIR /opt/server-app/
 COPY . .
 RUN ./mvnw clean package
 
-FROM amd64/openjdk:11-jre-slim
+FROM azul/zulu-openjdk:11
 
 VOLUME /tmp
 WORKDIR /opt/server-app/


### PR DESCRIPTION
Solve aarch64 support feature request in issue #81.

Commits:

**client-app, server-app: Use amd64/aarch64 capable Docker images**
    
The Docker images `amd64/openjdk:11-jdk-slim` are not usable on
aarch64 but support for both CPU architectures is requested in
issue 81.

So use the `azul/zulu-openjdk:11` Docker image which supports both
CPU architectures.

-----------------------------------------------

**nginx: Determine CPU arch with** `uname -m`
    
Support downloading `amd64` as well as `aarch64` NGINX tracer binaries
dependending on the CPU architecture of the host system.
    
If `uname -m` returns `x86_64`, then translate this to `amd64`.
    
The `ubuntu:24.04` Docker images are already multi-arch capable.

---------------------------------------

**README: Show the amd64/aarch64 multi-arch support**
    
Show in the "Prerequisites" section which CPU architectures are
supported.