### PR TITLE
binaries: Sync with official docs

### DIFF
--- a/binaries.md
+++ b/binaries.md
@@ -50,92 +50,92 @@ In the following list, *Glibc based Linux* stands for Linux versions that use Gl
 ### NGINX Plus R32
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.5.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.5.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.5.zip)
 
 ### NGINX Plus R31
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.3.zip)
 
 ### NGINX Plus R30
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.1.zip)
 
 ### NGINX Plus R29
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.4.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.4.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.4.zip)
 
 ### NGINX Plus R28
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.2.zip)
 
 ### NGINX Plus R27
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.6.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.6.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.6.zip)
 
 ### NGINX Plus R26
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.5.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.5.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.5.zip)
 
 ### NGINX Plus R25
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.3.zip)
 
 ### NGINX Plus R24
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.10.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.10.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.10.zip)
 
 ### NGINX Plus R23
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.5.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.5.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.5.zip)
 
 ### NGINX Plus R22
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.0.zip)
 
 ### NGINX Plus R21
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.9.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.9.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.9.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.9.zip)
 
 ### NGINX Plus R20
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.6.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.6.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.6.zip)
 
 ### NGINX Plus R19
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.3.zip)
 
 ### NGINX Plus R18
 
 * [NGINX Plus Official Repository](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-plus/):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.10.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.10.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.10.zip)
 
 ## NGINX
 
@@ -297,6 +297,24 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-glibc-nginx-1.29.0.zip)
   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-musl-nginx-1.29.0.zip)
 
+## NGINX 1.28.3
+
+* [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.28.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.28.3.zip)
+  * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.28.3.zip)
+  * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.28.3.zip)
+  * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.28.3.zip)
+  * [ppc64le Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-musl-nginx-1.28.3.zip)
+  * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-glibc-nginx-1.28.3.zip)
+  * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-musl-nginx-1.28.3.zip)
+
+* [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
+  * [amd64 Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.28.3_alpquic.zip)
+  * [aarch64 Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.28.3_alpquic.zip)
+  * [ppc64le Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-musl-nginx-1.28.3_alpquic.zip)
+  * [s390x Alpine Linux 3.22, 3.23](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-musl-nginx-1.28.3_alpquic.zip)
+
 ## NGINX 1.28.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
@@ -381,8 +399,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.27.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.27.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.27.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.27.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.27.2.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.27.2.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.27.2.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.27.2.zip)
@@ -393,8 +411,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.27.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.27.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.27.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.27.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.27.1.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.27.1.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.27.1.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.27.1.zip)
@@ -405,8 +423,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.27.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.27.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.27.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.27.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.27.0.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.27.0.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.27.0.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.27.0.zip)
@@ -428,6 +446,7 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
   * [amd64 Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.3_alpine.zip)
+  * [amd64 Alpine Linux 3.20, 3.21 with QUIC support](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.3_alpquic.zip)
   * [aarch64 Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.26.3_alpine.zip)
   * [ppc64le Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-musl-nginx-1.26.3_alpine.zip)
   * [s390x Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-musl-nginx-1.26.3_alpine.zip)
@@ -435,8 +454,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.26.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.26.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.26.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.2.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.26.2.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.26.2.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.26.2.zip)
@@ -445,13 +464,13 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-musl-nginx-1.26.2.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.2_alpine.zip)
+  * [amd64 Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.2_alpine.zip)
 
 ### NGINX 1.26.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.26.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.26.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.1.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.26.1.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.26.1.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.26.1.zip)
@@ -460,13 +479,13 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-musl-nginx-1.26.1.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.1_alpine.zip)
+  * [amd64 Alpine Linux 3.20, 3.21](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.1_alpine.zip)
 
 ### NGINX 1.26.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.26.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.26.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.26.0.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.26.0.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.26.0.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.26.0.zip)
@@ -477,8 +496,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.25.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.5.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.5.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.5.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.25.5.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.25.5.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.25.5.zip)
@@ -489,8 +508,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.25.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.4.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.4.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.4.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.25.4.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.25.4.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.25.4.zip)
@@ -501,8 +520,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.25.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.3.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.25.3.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.25.3.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.25.3.zip)
@@ -513,8 +532,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.25.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.2.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.25.2.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.25.2.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.25.2.zip)
@@ -522,12 +541,11 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
   * [s390x Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-glibc-nginx-1.25.2.zip)
   * [s390x Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-s390x-musl-nginx-1.25.2.zip)
 
-
 ### NGINX 1.25.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.1.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.25.1.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.25.1.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.25.1.zip)
@@ -538,8 +556,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.25.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.25.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.25.0.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.25.0.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.25.0.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.25.0.zip)
@@ -550,8 +568,8 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.24.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.24.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.24.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.24.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.24.0.zip)
   * [aarch64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-glibc-nginx-1.24.0.zip)
   * [aarch64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-aarch64-musl-nginx-1.24.0.zip)
   * [ppc64le Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-ppc64le-glibc-nginx-1.24.0.zip)
@@ -562,329 +580,323 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 ### NGINX 1.23.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.4.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.4.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.4.zip)
 
 ### NGINX 1.23.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.3.zip)
 
 ### NGINX 1.23.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.2.zip)
 
 ### NGINX 1.23.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.1.zip)
 
 ### NGINX 1.23.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.23.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.23.0.zip)
 
 ### NGINX 1.22.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.22.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.22.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.22.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.22.1.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.16](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.22.1_alpine.zip)
+  * [amd64 Alpine Linux 3.16](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.22.1_alpine.zip)
 
 ### NGINX 1.22.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.22.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.22.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.22.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.22.0.zip)
 
 ### NGINX 1.21.6
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.6.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.6.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.6.zip)
 
 ### NGINX 1.21.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.5.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.5.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.5.zip)
 
 ### NGINX 1.21.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.4.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.4.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.4.zip)
 
 ### NGINX 1.21.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.3.zip)
 
 ### NGINX 1.21.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.2.zip)
 
 ### NGINX 1.21.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.1.zip)
 
 ### NGINX 1.21.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.21.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.21.0.zip)
 
 ### NGINX 1.20.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.20.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.20.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.2.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.14/3.15](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.2_alpine.zip)
+  * [amd64 Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.2_alpine.zip)
 
 ### NGINX 1.20.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.20.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.20.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.1.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.1_alpine.zip)
+  * [amd64 Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.1_alpine.zip)
 
 ### NGINX 1.20.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.20.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.20.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.0.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.0_alpine.zip)
+  * [amd64 Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.20.0_alpine.zip)
 
 ### NGINX 1.19.10
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.10.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.10.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.10.zip)
 
 ### NGINX 1.19.9
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.9.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.9.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.9.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.9.zip)
 
 ### NGINX 1.19.8
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.8.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.8.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.8.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.8.zip)
 
 ### NGINX 1.19.7
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.7.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.7.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.7.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.7.zip)
 
 ### NGINX 1.19.6
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.6.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.6.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.6.zip)
 
 ### NGINX 1.19.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.5.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.5.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.5.zip)
 
 ### NGINX 1.19.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.4.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.4.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.4.zip)
 
 ### NGINX 1.19.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.3.zip)
 
 ### NGINX 1.19.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.2.zip)
 
 ### NGINX 1.19.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.1.zip)
 
 ### NGINX 1.19.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.19.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.19.0.zip)
 
 ### NGINX 1.18.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.18.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.18.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.18.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.18.0.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.12](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.18.0_alpine.zip)
+  * [amd64 Alpine Linux 3.12](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.18.0_alpine.zip)
 
 ### NGINX 1.17.10
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.10.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.10.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.10.zip)
 
 ### NGINX 1.17.9
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.9.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.9.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.9.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.9.zip)
 
 ### NGINX 1.17.8
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.8.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.8.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.8.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.8.zip)
 
 ### NGINX 1.17.7
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.7.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.7.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.7.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.7.zip)
 
 ### NGINX 1.17.6
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.6.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.6.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.6.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.6.zip)
 
 ### NGINX 1.17.5
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.5.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.5.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.5.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.5.zip)
 
 ### NGINX 1.17.4
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.4.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.4.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.4.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.4.zip)
 
 ### NGINX 1.17.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.3.zip)
 
 ### NGINX 1.17.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.2.zip)
 
 ### NGINX 1.17.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.1.zip)
 
 ### NGINX 1.17.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.17.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.17.0.zip)
 
 ### NGINX 1.16.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.16.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.16.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.16.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.16.1.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.11/3.10](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.16.1_alpine.zip)
+  * [amd64 Alpine Linux 3.11](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.16.1_alpine.zip)
 
 * [EPEL Repository](https://fedoraproject.org/wiki/EPEL):
-  * [CentOS/RHEL 7](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.16.1_amazon.zip)
+  * [CentOS/RHEL 8](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.16.1_amazon.zip)
 
 ### NGINX 1.16.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.16.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.16.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.16.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.16.0.zip)
 
 ### NGINX 1.15.12
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.12.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.12.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.12.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.12.zip)
 
 ### NGINX 1.15.10
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.10.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.10.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.10.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.10.zip)
 
 ### NGINX 1.15.3
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.3.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.3.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.3.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.3.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.3_alpine.zip)
-
-* [Debian Packages](https://www.debian.org/distrib/packages#view)
-  * [Debian 10/9](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.3_ubuntu.zip)
+  * [amd64 Alpine Linux 3.14](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.3_alpine.zip)
 
 ### NGINX 1.15.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.15.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.15.0.zip)
 
 ### NGINX 1.14.2
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.14.2.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.14.2.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.14.2.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.14.2.zip)
 
 * [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages):
-  * [Alpine Linux 3.9/3.8](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.14.2_alpine.zip)
-
-* [Debian Packages](https://www.debian.org/distrib/packages#view)
-  * [Debian 10/9](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.14.2_ubuntu.zip)
+  * [amd64 Alpine Linux 3.9/3.8](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.14.2_alpine.zip)
 
 ### NGINX 1.14.1
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.14.1.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.14.1.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.14.1.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.14.1.zip)
 
 ### NGINX 1.14.0
 
 * [NGINX Official Repository](http://nginx.org/en/linux_packages.html):
-  * [Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.14.0.zip)
-  * [Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.14.0.zip)
+  * [amd64 Glibc based Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.14.0.zip)
+  * [amd64 Alpine Linux](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-musl-nginx-1.14.0.zip)
 
 * [Ubuntu Packages](https://packages.ubuntu.com/):
   * [Ubuntu 18.04](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-nginx-1.14.0_ubuntu.zip)
@@ -904,10 +916,12 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
   * [OpenResty 1.27.1.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.27.1_compat.zip)
+  * [OpenResty 1.27.1.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.27.1_compat.zip)
     * Supported only on Amazon Linux and CentOS Stream 9 and later
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
   * [OpenResty 1.27.1.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.27.1_compat.zip)
+  * [OpenResty 1.27.1.2 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.27.1_compat.zip)
 
 ### OpenResty 1.25.3
 
@@ -925,7 +939,7 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
   * [OpenResty 1.21.4.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.21.4_compat.zip)
-    * Supported only on Amazon Linux and CentOS
+    * Supported only on Amazon Linux and CentOS Stream
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
   * [OpenResty 1.21.4.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.21.4.zip)
@@ -935,7 +949,7 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
   * [OpenResty 1.19.9.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.19.9_compat.zip)
-    * Supported only on Amazon Linux and CentOS
+    * Supported only on Amazon Linux and CentOS Stream
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
   * [OpenResty 1.19.9.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.19.9.zip)
@@ -945,9 +959,9 @@ In the following list, *Glibc based Linux* stands Linux versions that use Glibc 
 
 * [OpenResty Repository](https://openresty.org/en/linux-packages.html):
   * [OpenResty 1.19.3.1](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.19.3_compat.zip)
-    * Supported only on Amazon Linux and CentOS
+    * Supported only on Amazon Linux and CentOS Stream
   * [OpenResty 1.19.3.2](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.19.3_compat.zip)
-    * Supported only on Amazon Linux and CentOS
+    * Supported only on Amazon Linux and CentOS Stream
 
 * [OpenResty DockerHub containers](https://hub.docker.com/r/openresty/openresty)
   * [OpenResty 1.19.3.1 Debian](https://artifact-public.instana.io/artifactory/shared/com/instana/nginx_tracing/1.14.4/linux-amd64-glibc-openresty-1.19.3.zip)


### PR DESCRIPTION
* add amd64 CPU arch to most binaries without
* add missing NGINX 1.28.3
* drop Debian 9/10 parts
* add OpenResty 1.27.1.2
* explicitly mention CentOS Stream